### PR TITLE
Some fixes regarding "unclear"

### DIFF
--- a/1.0.0/critical.xslt
+++ b/1.0.0/critical.xslt
@@ -587,7 +587,7 @@
   </xsl:template>
 
   <xsl:template match="surplus">\secluded{<xsl:apply-templates/>}</xsl:template>
-  <xsl:template match="unclear">\emph{<xsl:apply-templates/> [?]}</xsl:template>
+  <xsl:template match="unclear" priority="1">\emph{<xsl:apply-templates/> [?]}</xsl:template>
   <xsl:template match="desc">\emph{<xsl:apply-templates/>}</xsl:template>
   <xsl:template match="abbr">\textsuperscript{<xsl:apply-templates/>}</xsl:template>
   <xsl:template match="mentioned">`<xsl:apply-templates/>'</xsl:template>

--- a/1.0.0/critical.xslt
+++ b/1.0.0/critical.xslt
@@ -778,7 +778,6 @@
           <!-- If wit contains a whitespace there is more than one witness. -->
           <xsl:if test="my:istrue($use-positive-apparatus)
                         or parent::app[@type='positive']
-                        or unclear
                         or @type='conjecture-supplied'
                         or @type='conjecture-removed'
                         or @type='conjecture-corrected'">
@@ -794,7 +793,6 @@
           <xsl:if test="not($lemma_text = my:format-lemma(.))
                         or my:istrue($use-positive-apparatus)
                         or parent::app[@type='positive']
-                        or unclear
                         or @type='correction-addition'">
             <!-- Check for preceding siblings that we need to put separator before -->
             <xsl:call-template name="varianttype">


### PR DESCRIPTION
Hi Michael,

I just submitted a PR to the `critical.xslt` file (v.1.0.0). I was having a problem when transforming this file:

https://github.com/scta-texts/wodehamordinatio/blob/master/b1-d3-qun/b1-d3-qun.xml#L15894

I noticed that if an unclear element was present in a lemma (see line 15894 of the xml), something happened that moved a `ledsidenote` into a `Bfootnote`, which is not allowed by reledmac. I'm not sure what the problem was, but this "solution" made the trick.

I also changed the priority of the `unclear` template in order to avoid an ambiguity.

Cheers,

Nick
